### PR TITLE
Add working directory controls to GLB merger

### DIFF
--- a/main.js
+++ b/main.js
@@ -1,0 +1,250 @@
+import { app, BrowserWindow, ipcMain, dialog } from 'electron';
+import path from 'node:path';
+import { spawn } from 'node:child_process';
+import fs from 'node:fs';
+import Store from 'electron-store';
+
+const store = new Store({ name: 'settings' });
+
+let mainWindow;
+let mergeInProgress = false;
+
+function resolveRendererPath() {
+  return path.join(process.cwd(), 'renderer', 'index.html');
+}
+
+async function createWindow() {
+  mainWindow = new BrowserWindow({
+    width: 980,
+    height: 720,
+    minWidth: 880,
+    minHeight: 600,
+    webPreferences: {
+      preload: path.join(process.cwd(), 'preload.js'),
+      nodeIntegration: false,
+      contextIsolation: true,
+    },
+    title: 'GLB Animation Merger',
+  });
+
+  await mainWindow.loadFile(resolveRendererPath());
+
+  if (process.env.ELECTRON_START_URL === 'devtools') {
+    mainWindow.webContents.openDevTools({ mode: 'detach' });
+  }
+}
+
+app.whenReady().then(() => {
+  createWindow();
+  app.on('activate', () => {
+    if (BrowserWindow.getAllWindows().length === 0) {
+      createWindow();
+    }
+  });
+});
+
+app.on('window-all-closed', () => {
+  if (process.platform !== 'darwin') {
+    app.quit();
+  }
+});
+
+function sendToRenderer(channel, payload) {
+  if (!mainWindow || mainWindow.isDestroyed()) return;
+  mainWindow.webContents.send(channel, payload);
+}
+
+function getNpxCommand() {
+  if (process.platform === 'win32') {
+    return 'npx.cmd';
+  }
+  if (process.platform === 'cygwin') {
+    return 'npx.cmd';
+  }
+  return 'npx';
+}
+
+function resolveWorkingDirectory() {
+  const configured = store.get('workDir', null);
+  if (!configured) {
+    return process.cwd();
+  }
+
+  try {
+    const stats = fs.statSync(configured);
+    if (!stats.isDirectory()) {
+      throw new Error(`Configured working folder is not a directory: ${configured}`);
+    }
+    return configured;
+  } catch (error) {
+    throw new Error(`Configured working folder is not accessible: ${configured}. ${error.message}`);
+  }
+}
+
+async function runMergeJob(job, workingDir) {
+  const { id, files, outputDir, outputName, transforms } = job;
+
+  if (!Array.isArray(files) || files.length === 0) {
+    throw new Error('No GLB files selected for this job.');
+  }
+  if (!outputDir) {
+    throw new Error('No output directory selected.');
+  }
+
+  const outputFile = outputName?.trim() ? outputName.trim() : `merged-${id}.glb`;
+  const outputPath = path.resolve(outputDir, outputFile);
+  const outputParent = path.dirname(outputPath);
+  if (!fs.existsSync(outputParent)) {
+    throw new Error(`Output directory does not exist: ${outputParent}`);
+  }
+
+  const base = files[0];
+  const rest = files.slice(1);
+
+  const npxCmd = getNpxCommand();
+  const cliArgs = [
+    '@gltf-transform/cli',
+    'merge',
+    base,
+    ...rest,
+    '--join',
+    '--output',
+    outputPath,
+  ];
+
+  const appliedTransforms = Array.isArray(transforms) && transforms.length
+    ? transforms
+    : ['dedup', 'prune'];
+
+  for (const transform of appliedTransforms) {
+    cliArgs.push('-t', transform);
+  }
+
+  sendToRenderer('merge-status', { jobId: id, status: 'running', outputPath });
+  sendToRenderer('merge-log', { jobId: id, type: 'info', text: `Running glTF-Transform merge for ${path.basename(outputPath)}...` });
+
+  await new Promise((resolve, reject) => {
+    const child = spawn(npxCmd, cliArgs, {
+      cwd: workingDir ?? process.cwd(),
+      env: { ...process.env },
+    });
+
+    child.stdout.on('data', (chunk) => {
+      sendToRenderer('merge-log', { jobId: id, type: 'out', text: chunk.toString() });
+    });
+
+    child.stderr.on('data', (chunk) => {
+      sendToRenderer('merge-log', { jobId: id, type: 'err', text: chunk.toString() });
+    });
+
+    child.on('error', (err) => {
+      sendToRenderer('merge-log', { jobId: id, type: 'err', text: err.message });
+      reject(err);
+    });
+
+    child.on('close', (code) => {
+      if (code === 0) {
+        resolve();
+      } else {
+        const error = new Error(`glTF-Transform exited with code ${code}`);
+        reject(error);
+      }
+    });
+  });
+
+  sendToRenderer('merge-log', { jobId: id, type: 'info', text: `Finished job ${id}. Saved to ${outputPath}` });
+  sendToRenderer('merge-status', { jobId: id, status: 'success', outputPath });
+}
+
+async function runMergeQueue(jobs, workingDir) {
+  for (const job of jobs) {
+    sendToRenderer('merge-status', { jobId: job.id, status: 'pending' });
+  }
+
+  for (const job of jobs) {
+    try {
+      await runMergeJob(job, workingDir);
+    } catch (err) {
+      sendToRenderer('merge-log', { jobId: job.id, type: 'err', text: err?.message ?? String(err) });
+      sendToRenderer('merge-status', { jobId: job.id, status: 'failed' });
+    }
+  }
+}
+
+ipcMain.handle('pick-files', async () => {
+  const result = await dialog.showOpenDialog(mainWindow, {
+    title: 'Pick one or more .glb files',
+    filters: [{ name: 'GLB', extensions: ['glb'] }],
+    properties: ['openFile', 'multiSelections'],
+  });
+  return result.canceled ? [] : result.filePaths;
+});
+
+ipcMain.handle('pick-output-dir', async () => {
+  const result = await dialog.showOpenDialog(mainWindow, {
+    title: 'Choose output folder',
+    properties: ['openDirectory', 'createDirectory'],
+  });
+  const dir = result.canceled ? null : result.filePaths[0];
+  if (dir) {
+    store.set('lastOutputDir', dir);
+  }
+  return dir;
+});
+
+ipcMain.handle('pick-work-dir', async () => {
+  const result = await dialog.showOpenDialog(mainWindow, {
+    title: 'Choose working folder',
+    properties: ['openDirectory', 'createDirectory'],
+  });
+  const dir = result.canceled ? null : result.filePaths[0];
+  if (dir) {
+    store.set('workDir', dir);
+  }
+  return dir;
+});
+
+ipcMain.handle('clear-work-dir', async () => {
+  if (store.has('workDir')) {
+    store.delete('workDir');
+    return true;
+  }
+  return false;
+});
+
+ipcMain.handle('get-pref', async (_e, key, fallback) => {
+  return store.get(key, fallback);
+});
+
+ipcMain.handle('set-pref', async (_e, key, value) => {
+  store.set(key, value);
+  return true;
+});
+
+ipcMain.handle('start-merge', async (_e, jobs) => {
+  if (mergeInProgress) {
+    throw new Error('A merge is already in progress. Please wait.');
+  }
+  if (!Array.isArray(jobs) || jobs.length === 0) {
+    throw new Error('No jobs to merge.');
+  }
+
+  const workingDir = resolveWorkingDirectory();
+
+  mergeInProgress = true;
+  sendToRenderer('merge-log', { jobId: null, type: 'info', text: `Starting ${jobs.length} merge job(s)...` });
+  sendToRenderer('merge-log', { jobId: null, type: 'info', text: `Using working folder: ${workingDir}` });
+
+  try {
+    await runMergeQueue(jobs, workingDir);
+    sendToRenderer('merge-log', { jobId: null, type: 'info', text: 'All merge jobs finished.' });
+    return { ok: true };
+  } catch (err) {
+    sendToRenderer('merge-log', { jobId: null, type: 'err', text: err?.message ?? String(err) });
+    return { ok: false, error: err?.message ?? String(err) };
+  } finally {
+    mergeInProgress = false;
+  }
+});
+
+ipcMain.handle('is-merging', async () => mergeInProgress);

--- a/package.json
+++ b/package.json
@@ -1,0 +1,20 @@
+{
+  "name": "glb-anim-merger",
+  "version": "1.0.0",
+  "private": true,
+  "description": "Electron GUI to merge multiple GLB files into one with combined animations.",
+  "main": "main.js",
+  "type": "module",
+  "scripts": {
+    "start": "electron .",
+    "build": "echo \"Use electron-builder or forge if you want installers\"",
+    "postinstall": "patch-package || true"
+  },
+  "dependencies": {
+    "@gltf-transform/cli": "^3.10.0",
+    "electron-store": "^9.0.0"
+  },
+  "devDependencies": {
+    "electron": "^31.3.0"
+  }
+}

--- a/preload.js
+++ b/preload.js
@@ -1,0 +1,20 @@
+import { contextBridge, ipcRenderer } from 'electron';
+
+const api = {
+  pickFiles: () => ipcRenderer.invoke('pick-files'),
+  pickOutputDir: () => ipcRenderer.invoke('pick-output-dir'),
+  pickWorkDir: () => ipcRenderer.invoke('pick-work-dir'),
+  getPref: (key, fallback = null) => ipcRenderer.invoke('get-pref', key, fallback),
+  setPref: (key, value) => ipcRenderer.invoke('set-pref', key, value),
+  startMerge: (jobs) => ipcRenderer.invoke('start-merge', jobs),
+  isMerging: () => ipcRenderer.invoke('is-merging'),
+  clearWorkDir: () => ipcRenderer.invoke('clear-work-dir'),
+  onMergeLog: (callback) => {
+    ipcRenderer.on('merge-log', (_event, payload) => callback(payload));
+  },
+  onMergeStatus: (callback) => {
+    ipcRenderer.on('merge-status', (_event, payload) => callback(payload));
+  },
+};
+
+contextBridge.exposeInMainWorld('glbMerger', api);

--- a/renderer/index.html
+++ b/renderer/index.html
@@ -1,0 +1,82 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta http-equiv="X-UA-Compatible" content="IE=edge" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>GLB Animation Merger</title>
+    <link rel="stylesheet" href="styles.css" />
+  </head>
+  <body>
+    <header class="app-header">
+      <div class="title-group">
+        <h1>GLB Animation Merger</h1>
+        <p class="subtitle">
+          Merge identical GLB rigs and collect all unique animations into a single output.
+        </p>
+      </div>
+      <div class="header-actions">
+        <button id="addJobBtn" class="primary">Add Merge Job</button>
+        <button id="mergeAllBtn" class="accent">Merge All Jobs</button>
+      </div>
+    </header>
+
+    <section class="workspace-bar" aria-label="Working folder controls">
+      <div class="workspace-text">
+        <h2>Working Folder</h2>
+        <p id="workingDirDisplay" class="workspace-path">Using app directory</p>
+      </div>
+      <div class="workspace-actions">
+        <button id="chooseWorkingDirBtn" class="secondary">Choose Folder…</button>
+        <button id="clearWorkingDirBtn" class="ghost">Reset</button>
+      </div>
+    </section>
+
+    <main>
+      <section id="jobsContainer" class="jobs"></section>
+      <aside class="log-panel">
+        <div class="log-header">
+          <h2>Activity Log</h2>
+          <button id="clearLogBtn" class="ghost">Clear</button>
+        </div>
+        <pre id="log" class="log-output" aria-live="polite"></pre>
+      </aside>
+    </main>
+
+    <template id="jobTemplate">
+      <article class="job">
+        <header class="job-header">
+          <div>
+            <h2 class="job-title"></h2>
+            <span class="job-status">Idle</span>
+          </div>
+          <div class="job-actions">
+            <button class="ghost" data-action="duplicate">Duplicate</button>
+            <button class="ghost" data-action="remove">Remove</button>
+          </div>
+        </header>
+        <div class="job-body">
+          <div class="job-row">
+            <label>Files</label>
+            <div class="file-list" data-role="files"></div>
+            <div class="button-row">
+              <button class="secondary" data-action="add-files">Add Files</button>
+              <button class="ghost" data-action="clear-files">Clear</button>
+            </div>
+          </div>
+          <div class="job-row">
+            <label>Output Folder</label>
+            <div class="output-path" data-role="output-dir">Not set</div>
+            <button class="secondary" data-action="choose-output">Choose…</button>
+          </div>
+          <div class="job-row">
+            <label for="outputName">Output Filename</label>
+            <input class="text" data-role="output-name" placeholder="merged.glb" />
+          </div>
+        </div>
+      </article>
+    </template>
+
+    <script type="module" src="renderer.js"></script>
+  </body>
+</html>

--- a/renderer/renderer.js
+++ b/renderer/renderer.js
@@ -1,0 +1,376 @@
+const $ = (selector, parent = document) => parent.querySelector(selector);
+
+const jobsContainer = $('#jobsContainer');
+const jobTemplate = $('#jobTemplate');
+const logEl = $('#log');
+const clearLogBtn = $('#clearLogBtn');
+const addJobBtn = $('#addJobBtn');
+const mergeAllBtn = $('#mergeAllBtn');
+const workingDirDisplay = $('#workingDirDisplay');
+const chooseWorkingDirBtn = $('#chooseWorkingDirBtn');
+const clearWorkingDirBtn = $('#clearWorkingDirBtn');
+
+let jobIdCounter = 1;
+let jobs = [];
+let workingDir = null;
+
+function makeJob(partial = {}) {
+  return {
+    id: jobIdCounter++,
+    files: [],
+    outputDir: null,
+    outputName: '',
+    status: 'Idle',
+    transforms: ['dedup', 'prune'],
+    ...partial,
+  };
+}
+
+function baseName(filepath) {
+  return filepath ? filepath.split(/[/\\]/).pop() : '';
+}
+
+function uniqueAppend(list, items) {
+  const set = new Set(list);
+  for (const item of items) {
+    if (!set.has(item)) {
+      list.push(item);
+      set.add(item);
+    }
+  }
+}
+
+function renderJobs() {
+  jobsContainer.innerHTML = '';
+
+  if (jobs.length === 0) {
+    const empty = document.createElement('div');
+    empty.className = 'empty-state';
+    empty.innerHTML = `
+      <h2>No jobs yet</h2>
+      <p>Add a merge job to start combining GLB animations.</p>
+    `;
+    jobsContainer.appendChild(empty);
+    return;
+  }
+
+  jobs.forEach((job, index) => {
+    const fragment = jobTemplate.content.cloneNode(true);
+    const root = fragment.querySelector('.job');
+    root.dataset.jobId = String(job.id);
+
+    const title = $('.job-title', root);
+    title.textContent = `Job ${index + 1}`;
+
+    const statusEl = $('.job-status', root);
+    statusEl.textContent = job.status;
+    statusEl.className = `job-status status-${job.status.toLowerCase()}`;
+
+    const filesContainer = $('[data-role="files"]', root);
+    filesContainer.innerHTML = '';
+
+    if (job.files.length === 0) {
+      const placeholder = document.createElement('div');
+      placeholder.className = 'file-placeholder';
+      placeholder.textContent = 'No files selected. Add at least one .glb file.';
+      filesContainer.appendChild(placeholder);
+    } else {
+      job.files.forEach((file, idx) => {
+        const pill = document.createElement('div');
+        pill.className = 'file-pill';
+        pill.dataset.index = String(idx);
+
+        const label = document.createElement('span');
+        label.className = 'file-label';
+        label.textContent = `${baseName(file)}${idx === 0 ? ' (base)' : ''}`;
+        pill.appendChild(label);
+
+        const controls = document.createElement('div');
+        controls.className = 'file-pill-actions';
+
+        const upBtn = document.createElement('button');
+        upBtn.className = 'ghost';
+        upBtn.textContent = '↑';
+        upBtn.title = 'Move up';
+        upBtn.dataset.action = 'move-up';
+        upBtn.disabled = idx === 0;
+
+        const downBtn = document.createElement('button');
+        downBtn.className = 'ghost';
+        downBtn.textContent = '↓';
+        downBtn.title = 'Move down';
+        downBtn.dataset.action = 'move-down';
+        downBtn.disabled = idx === job.files.length - 1;
+
+        const removeBtn = document.createElement('button');
+        removeBtn.className = 'ghost';
+        removeBtn.textContent = '✕';
+        removeBtn.title = 'Remove';
+        removeBtn.dataset.action = 'remove-file';
+
+        controls.append(upBtn, downBtn, removeBtn);
+        pill.appendChild(controls);
+        filesContainer.appendChild(pill);
+      });
+    }
+
+    const outputDirEl = $('[data-role="output-dir"]', root);
+    outputDirEl.textContent = job.outputDir || 'Not set';
+
+    const outputNameInput = $('[data-role="output-name"]', root);
+    outputNameInput.value = job.outputName;
+    outputNameInput.addEventListener('input', (event) => {
+      job.outputName = event.target.value;
+    });
+
+    root.addEventListener('click', async (event) => {
+      const target = event.target;
+      if (!(target instanceof HTMLElement)) return;
+      const action = target.dataset.action;
+      if (!action) return;
+
+      switch (action) {
+        case 'remove':
+          jobs = jobs.filter((j) => j.id !== job.id);
+          renderJobs();
+          break;
+        case 'duplicate': {
+          const clone = makeJob({
+            files: [...job.files],
+            outputDir: job.outputDir,
+            outputName: job.outputName,
+            status: 'Idle',
+            transforms: [...job.transforms],
+          });
+          jobs.splice(index + 1, 0, clone);
+          renderJobs();
+          break;
+        }
+        case 'add-files':
+          pickFilesForJob(job);
+          break;
+        case 'clear-files':
+          job.files = [];
+          renderJobs();
+          break;
+        case 'choose-output':
+          chooseOutputDir(job);
+          break;
+        case 'move-up': {
+          const idx = Number(target.closest('.file-pill')?.dataset.index ?? -1);
+          if (idx > 0) {
+            [job.files[idx - 1], job.files[idx]] = [job.files[idx], job.files[idx - 1]];
+            renderJobs();
+          }
+          break;
+        }
+        case 'move-down': {
+          const idx = Number(target.closest('.file-pill')?.dataset.index ?? -1);
+          if (idx >= 0 && idx < job.files.length - 1) {
+            [job.files[idx + 1], job.files[idx]] = [job.files[idx], job.files[idx + 1]];
+            renderJobs();
+          }
+          break;
+        }
+        case 'remove-file': {
+          const idx = Number(target.closest('.file-pill')?.dataset.index ?? -1);
+          if (idx >= 0) {
+            job.files.splice(idx, 1);
+            renderJobs();
+          }
+          break;
+        }
+        default:
+          break;
+      }
+    });
+
+    jobsContainer.appendChild(fragment);
+  });
+}
+
+async function pickFilesForJob(job) {
+  const selections = await window.glbMerger.pickFiles();
+  if (!selections || selections.length === 0) {
+    return;
+  }
+  uniqueAppend(job.files, selections);
+  job.status = 'Idle';
+  renderJobs();
+}
+
+async function chooseOutputDir(job) {
+  const dir = await window.glbMerger.pickOutputDir();
+  if (dir) {
+    job.outputDir = dir;
+    await window.glbMerger.setPref('lastOutputDir', dir);
+    job.status = 'Idle';
+    renderJobs();
+  }
+}
+
+function log(message, type = 'info', jobId = null) {
+  const prefix = jobId ? `[Job ${jobIndex(jobId) ?? jobId}]` : '[App]';
+  const decorated = `${new Date().toLocaleTimeString()} ${prefix} ${message}`;
+  logEl.textContent += `${decorated}\n`;
+  logEl.scrollTop = logEl.scrollHeight;
+  logEl.dataset.lastType = type;
+}
+
+function updateWorkingDirDisplay() {
+  if (!workingDirDisplay) return;
+  if (!workingDir) {
+    workingDirDisplay.textContent = 'Using app directory';
+    workingDirDisplay.title = 'The app directory will be used as the working folder.';
+  } else {
+    workingDirDisplay.textContent = workingDir;
+    workingDirDisplay.title = workingDir;
+  }
+}
+
+async function selectWorkingDir() {
+  const dir = await window.glbMerger.pickWorkDir();
+  if (dir) {
+    workingDir = dir;
+    updateWorkingDirDisplay();
+    log(`Working folder set to ${dir}`);
+  }
+}
+
+async function resetWorkingDir() {
+  const changed = await window.glbMerger.clearWorkDir();
+  workingDir = null;
+  updateWorkingDirDisplay();
+  if (changed) {
+    log('Working folder reset to the app directory.');
+  }
+}
+
+function jobIndex(jobId) {
+  const idx = jobs.findIndex((j) => j.id === jobId);
+  return idx >= 0 ? idx + 1 : null;
+}
+
+async function handleMergeAll() {
+  if (await window.glbMerger.isMerging()) {
+    log('A merge is already running. Please wait for it to finish.', 'warn');
+    return;
+  }
+
+  if (jobs.length === 0) {
+    log('Add at least one job before merging.', 'warn');
+    return;
+  }
+
+  const invalidJobs = jobs.filter((job) => job.files.length === 0 || !job.outputDir);
+  if (invalidJobs.length > 0) {
+    invalidJobs.forEach((job) => {
+      if (job.files.length === 0) {
+        log(`Job ${jobIndex(job.id) ?? job.id} has no files selected.`, 'error', job.id);
+      }
+      if (!job.outputDir) {
+        log(`Job ${jobIndex(job.id) ?? job.id} has no output directory.`, 'error', job.id);
+      }
+    });
+    return;
+  }
+
+  jobs.forEach((job) => {
+    job.status = 'Queued';
+  });
+  renderJobs();
+
+  const payload = jobs.map((job) => ({
+    id: job.id,
+    files: job.files,
+    outputDir: job.outputDir,
+    outputName: job.outputName,
+    transforms: job.transforms,
+  }));
+
+  try {
+    const result = await window.glbMerger.startMerge(payload);
+    if (!result?.ok) {
+      log(result?.error || 'Merge failed to start.', 'error');
+    }
+  } catch (error) {
+    log(error?.message || String(error), 'error');
+  }
+}
+
+function updateJobStatus(jobId, status, extra = {}) {
+  const job = jobs.find((j) => j.id === jobId);
+  if (!job) return;
+  job.status = statusLabel(status);
+  if (extra.outputPath) {
+    job.outputName = extra.outputPath.split(/[/\\]/).pop();
+  }
+  renderJobs();
+}
+
+function statusLabel(status) {
+  switch (status) {
+    case 'pending':
+      return 'Queued';
+    case 'running':
+      return 'Running';
+    case 'success':
+      return 'Completed';
+    case 'failed':
+      return 'Failed';
+    default:
+      return status ?? 'Idle';
+  }
+}
+
+function setupLogListeners() {
+  window.glbMerger.onMergeLog(({ jobId, type, text }) => {
+    const lines = text.split(/\r?\n/).filter(Boolean);
+    for (const line of lines) {
+      log(line, type, jobId ?? undefined);
+    }
+  });
+
+  window.glbMerger.onMergeStatus(({ jobId, status, outputPath }) => {
+    if (jobId != null) {
+      updateJobStatus(jobId, status, { outputPath });
+    }
+  });
+}
+
+function setupUi() {
+  addJobBtn.addEventListener('click', async () => {
+    const lastOutputDir = await window.glbMerger.getPref('lastOutputDir', null);
+    const job = makeJob({ outputDir: lastOutputDir });
+    jobs.push(job);
+    renderJobs();
+  });
+
+  mergeAllBtn.addEventListener('click', handleMergeAll);
+
+  clearLogBtn.addEventListener('click', () => {
+    logEl.textContent = '';
+  });
+
+  if (chooseWorkingDirBtn) {
+    chooseWorkingDirBtn.addEventListener('click', selectWorkingDir);
+  }
+  if (clearWorkingDirBtn) {
+    clearWorkingDirBtn.addEventListener('click', resetWorkingDir);
+  }
+}
+
+function init() {
+  setupUi();
+  setupLogListeners();
+
+  (async () => {
+    const lastOutputDir = await window.glbMerger.getPref('lastOutputDir', null);
+    workingDir = await window.glbMerger.getPref('workDir', null);
+    updateWorkingDirDisplay();
+    jobs.push(makeJob({ outputDir: lastOutputDir }));
+    renderJobs();
+  })();
+}
+
+init();

--- a/renderer/styles.css
+++ b/renderer/styles.css
@@ -1,0 +1,335 @@
+:root {
+  color-scheme: light dark;
+  --bg: #f5f7fb;
+  --panel-bg: #ffffffcc;
+  --panel-border: #dce0eb;
+  --text: #1b1f36;
+  --muted: #5d6584;
+  --primary: #2563eb;
+  --primary-text: #ffffff;
+  --accent: #059669;
+  --accent-text: #ffffff;
+  --ghost-border: #c9cdd9;
+  --danger: #dc2626;
+  --radius: 12px;
+  font-family: 'Inter', 'Segoe UI', sans-serif;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  padding: 0;
+  background: var(--bg);
+  color: var(--text);
+  min-height: 100vh;
+  display: flex;
+  flex-direction: column;
+}
+
+body::before {
+  content: '';
+  position: fixed;
+  inset: 0;
+  background: radial-gradient(circle at top left, rgba(37, 99, 235, 0.15), transparent 40%),
+    radial-gradient(circle at bottom right, rgba(5, 150, 105, 0.12), transparent 45%);
+  pointer-events: none;
+  z-index: -1;
+}
+
+.app-header {
+  padding: 24px 32px;
+  display: flex;
+  align-items: flex-end;
+  justify-content: space-between;
+  gap: 16px;
+}
+
+.title-group h1 {
+  margin: 0;
+  font-size: 28px;
+  font-weight: 700;
+}
+
+.subtitle {
+  margin: 6px 0 0;
+  color: var(--muted);
+}
+
+.header-actions {
+  display: flex;
+  gap: 12px;
+}
+
+.workspace-bar {
+  margin: 0 32px 20px;
+  background: var(--panel-bg);
+  border: 1px solid var(--panel-border);
+  border-radius: var(--radius);
+  padding: 16px 20px;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 16px;
+  backdrop-filter: blur(6px);
+  box-shadow: 0 10px 24px rgba(15, 23, 42, 0.08);
+}
+
+.workspace-text h2 {
+  margin: 0;
+  font-size: 18px;
+}
+
+.workspace-path {
+  margin: 6px 0 0;
+  color: var(--muted);
+  font-size: 13px;
+  word-break: break-all;
+}
+
+.workspace-actions {
+  display: flex;
+  gap: 10px;
+}
+
+button {
+  border: none;
+  border-radius: var(--radius);
+  padding: 10px 18px;
+  font-weight: 600;
+  font-size: 14px;
+  cursor: pointer;
+  transition: transform 0.15s ease, box-shadow 0.15s ease;
+}
+
+button:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
+button.primary {
+  background: var(--primary);
+  color: var(--primary-text);
+  box-shadow: 0 8px 16px rgba(37, 99, 235, 0.2);
+}
+
+button.accent {
+  background: var(--accent);
+  color: var(--accent-text);
+  box-shadow: 0 8px 16px rgba(5, 150, 105, 0.2);
+}
+
+button.secondary {
+  background: rgba(37, 99, 235, 0.12);
+  color: var(--primary);
+}
+
+button.ghost {
+  background: transparent;
+  color: var(--muted);
+  border: 1px solid var(--ghost-border);
+  padding: 6px 10px;
+  font-size: 13px;
+}
+
+button:hover:not(:disabled) {
+  transform: translateY(-1px);
+}
+
+main {
+  flex: 1;
+  display: grid;
+  grid-template-columns: 2fr 1fr;
+  gap: 24px;
+  padding: 0 32px 32px;
+}
+
+.jobs {
+  display: flex;
+  flex-direction: column;
+  gap: 20px;
+}
+
+.job {
+  background: var(--panel-bg);
+  border: 1px solid var(--panel-border);
+  border-radius: var(--radius);
+  padding: 20px;
+  backdrop-filter: blur(6px);
+  box-shadow: 0 10px 24px rgba(15, 23, 42, 0.08);
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+}
+
+.job-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 12px;
+}
+
+.job-header h2 {
+  margin: 0;
+  font-size: 20px;
+}
+
+.job-status {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  font-size: 13px;
+  color: var(--muted);
+  margin-top: 4px;
+}
+
+.job-status.status-idle {
+  color: var(--muted);
+}
+
+.job-status.status-running {
+  color: var(--primary);
+}
+
+.job-status.status-queued {
+  color: var(--muted);
+}
+
+.job-status.status-completed {
+  color: var(--accent);
+}
+
+.job-status.status-failed {
+  color: var(--danger);
+}
+
+.job-body {
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+}
+
+.job-row {
+  display: grid;
+  grid-template-columns: 140px 1fr auto;
+  gap: 12px;
+  align-items: start;
+}
+
+.job-row label {
+  font-weight: 600;
+  padding-top: 8px;
+}
+
+.file-list {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.file-placeholder {
+  padding: 12px;
+  border-radius: var(--radius);
+  border: 1px dashed var(--ghost-border);
+  color: var(--muted);
+  font-size: 14px;
+}
+
+.file-pill {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  background: rgba(37, 99, 235, 0.08);
+  border-radius: var(--radius);
+  padding: 10px 12px;
+  gap: 12px;
+}
+
+.file-pill-actions {
+  display: flex;
+  gap: 6px;
+}
+
+.file-label {
+  font-weight: 500;
+}
+
+.button-row {
+  display: flex;
+  gap: 8px;
+}
+
+.output-path {
+  background: rgba(148, 163, 184, 0.12);
+  border-radius: var(--radius);
+  padding: 10px 12px;
+  font-size: 14px;
+  color: var(--muted);
+  word-break: break-all;
+}
+
+input.text {
+  width: 100%;
+  padding: 10px 12px;
+  border-radius: var(--radius);
+  border: 1px solid var(--panel-border);
+  font-size: 14px;
+}
+
+.log-panel {
+  background: var(--panel-bg);
+  border: 1px solid var(--panel-border);
+  border-radius: var(--radius);
+  padding: 20px;
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  height: fit-content;
+  position: sticky;
+  top: 24px;
+  max-height: calc(100vh - 96px);
+}
+
+.log-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+}
+
+.log-output {
+  margin: 0;
+  background: rgba(15, 23, 42, 0.85);
+  color: #f8fafc;
+  padding: 16px;
+  border-radius: var(--radius);
+  font-family: 'JetBrains Mono', 'Fira Code', monospace;
+  font-size: 13px;
+  line-height: 1.6;
+  overflow: auto;
+  min-height: 200px;
+  max-height: 480px;
+  box-shadow: inset 0 0 0 1px rgba(148, 163, 184, 0.2);
+}
+
+.empty-state {
+  background: rgba(255, 255, 255, 0.7);
+  border: 1px dashed var(--ghost-border);
+  border-radius: var(--radius);
+  text-align: center;
+  padding: 48px 24px;
+  color: var(--muted);
+  display: grid;
+  gap: 8px;
+}
+
+@media (max-width: 1024px) {
+  main {
+    grid-template-columns: 1fr;
+  }
+
+  .log-panel {
+    position: static;
+  }
+}


### PR DESCRIPTION
## Summary
- add a working-folder control bar in the renderer so users can choose or reset the merge directory
- wire new IPC helpers and persistence so the selected folder is saved and used for future runs
- update the main process to validate the folder and run glTF-Transform from the configured working directory with improved logging

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68dc3de15464832aabea1513b5436f65