### PR TITLE
Handle missing parent window in file pickers

### DIFF
--- a/main.js
+++ b/main.js
@@ -201,24 +201,30 @@ async function runMergeQueue(jobs, workingDir) {
 ipcMain.handle('pick-files', async () => {
 
   const browserWindow = getDialogParent();
-  const result = await dialog.showOpenDialog(browserWindow ?? undefined, {
+  const options = {
 
     title: 'Pick one or more .glb files',
     filters: [{ name: 'GLB', extensions: ['glb'] }],
     properties: ['openFile', 'multiSelections'],
-  });
+  };
+  const result = browserWindow
+    ? await dialog.showOpenDialog(browserWindow, options)
+    : await dialog.showOpenDialog(options);
   return result.canceled ? [] : result.filePaths;
 });
 
 ipcMain.handle('pick-output-dir', async () => {
 
   const browserWindow = getDialogParent();
-  const result = await dialog.showOpenDialog(browserWindow ?? undefined, {
+  const options = {
     title: 'Choose output folder',
     defaultPath: store.get('lastOutputDir', undefined),
 
     properties: ['openDirectory', 'createDirectory'],
-  });
+  };
+  const result = browserWindow
+    ? await dialog.showOpenDialog(browserWindow, options)
+    : await dialog.showOpenDialog(options);
   const dir = result.canceled ? null : result.filePaths[0];
   if (dir) {
     store.set('lastOutputDir', dir);
@@ -229,12 +235,15 @@ ipcMain.handle('pick-output-dir', async () => {
 
 ipcMain.handle('pick-work-dir', async () => {
   const browserWindow = getDialogParent();
-  const result = await dialog.showOpenDialog(browserWindow ?? undefined, {
+  const options = {
     title: 'Choose working folder',
     defaultPath: store.get('workDir', process.cwd()),
 
     properties: ['openDirectory', 'createDirectory'],
-  });
+  };
+  const result = browserWindow
+    ? await dialog.showOpenDialog(browserWindow, options)
+    : await dialog.showOpenDialog(options);
   const dir = result.canceled ? null : result.filePaths[0];
   if (dir) {
     store.set('workDir', dir);


### PR DESCRIPTION
## Summary
- update the file dialog helpers to branch on whether a BrowserWindow is available
- keep existing preference and path handling while avoiding passing undefined parent windows

## Testing
- not run (not supported in this environment)


------
https://chatgpt.com/codex/tasks/task_e_68dc4b218394832a95d651f8cacf9454