### PR TITLE
Switch preload script to CommonJS

### DIFF
--- a/main.js
+++ b/main.js
@@ -1,5 +1,6 @@
 import { app, BrowserWindow, ipcMain, dialog } from 'electron';
 import path from 'node:path';
+import { fileURLToPath } from 'node:url';
 import { spawn } from 'node:child_process';
 import fs from 'node:fs';
 import Store from 'electron-store';
@@ -37,9 +38,7 @@ async function createWindow() {
     minWidth: 880,
     minHeight: 600,
     webPreferences: {
-
-      preload: path.join(app.getAppPath(), 'preload.js'),
-
+      preload: fileURLToPath(new URL('./preload.cjs', import.meta.url)),
       nodeIntegration: false,
       contextIsolation: true,
     },

--- a/preload.cjs
+++ b/preload.cjs
@@ -1,4 +1,4 @@
-import { contextBridge, ipcRenderer } from 'electron';
+const { contextBridge, ipcRenderer } = require('electron');
 
 const api = {
   pickFiles: () => ipcRenderer.invoke('pick-files'),


### PR DESCRIPTION
## Summary
- convert the preload script to CommonJS so it can be required by Electron
- update the BrowserWindow configuration to load the renamed preload file

## Testing
- `npm start` *(fails: Electron cannot find libatk-1.0.so.0 in this container)*

------
https://chatgpt.com/codex/tasks/task_e_68dc4f1d9b40832a881199069907c2fb