### PR TITLE
Add renderer preload API guard and error banner

### DIFF
--- a/renderer/styles.css
+++ b/renderer/styles.css
@@ -29,6 +29,31 @@ body {
   flex-direction: column;
 }
 
+.error-banner {
+  margin: 16px 32px 0;
+  border-radius: var(--radius);
+  border: 1px solid rgba(220, 38, 38, 0.4);
+  background: rgba(254, 226, 226, 0.8);
+  color: var(--danger);
+  padding: 16px 20px;
+  backdrop-filter: blur(6px);
+  box-shadow: 0 10px 24px rgba(220, 38, 38, 0.12);
+}
+
+.error-banner p {
+  margin: 8px 0 0;
+  color: inherit;
+}
+
+.error-banner ul {
+  margin: 12px 0 0 20px;
+  padding: 0;
+}
+
+.error-banner li {
+  margin: 4px 0;
+}
+
 body::before {
   content: '';
   position: fixed;


### PR DESCRIPTION
## Summary
- verify the renderer preload bridge exposes the expected API before wiring up the UI
- surface an in-app error banner and disable controls when initialization fails
- guard renderer helpers so they bail early if the preload bridge is unavailable
- add styling for the fatal error banner

## Testing
- Not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68dc53e0b6f4832a807f6c9b784a7cd9